### PR TITLE
Add missing requirement used in lms/lms.py

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ edx-rest-api-client==1.2.1
 jupyter
 runipy
 seaborn
+lazy


### PR DESCRIPTION
The "lazy" module is used all over lms/lms.py but it doesn't seem to be in any requirements files. Not having it causes locust to not start.