### PR TITLE
locust task added for credentials API endpoints

### DIFF
--- a/credentials/config.py
+++ b/credentials/config.py
@@ -5,7 +5,7 @@ import os
 # URL CONFIGURATION
 CREDENTIAL_SERVICE_URL = os.environ.get(
     'CREDENTIAL_SERVICE_URL',
-    'http://localhost:8150'
+    'http://127.0.0.1:8150'
 ).strip('/')
 
 CREDENTIAL_API_URL = os.environ.get(
@@ -13,9 +13,18 @@ CREDENTIAL_API_URL = os.environ.get(
     '{}/api/v1/'.format(CREDENTIAL_SERVICE_URL)
 )
 
+LMS_ROOT_URL = os.environ.get(
+    'LMS_ROOT_URL',
+    'http://127.0.0.1:8000'
+).strip('/')
+
+# Default program_id will 3, for which we have corresponding program in programs service fixtures.
+PROGRAM_ID = os.environ.get('PROGRAM_ID', 3)
 
 # JWT CONFIGURATION
-JWT_AUDIENCE = os.environ.get('JWT_AUDIENCE', 'credentials-key')
-JWT_ISSUER = os.environ.get('JWT_ISSUER', 'http://localhost:8000/oauth2')
-JWT_EXPIRATION_DELTA = int(os.environ.get('JWT_EXPIRATION_DELTA', 1))
-JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'credentials-secret')
+JWT = {
+    "JWT_AUDIENCE": os.environ.get('JWT_AUDIENCE', 'credentials-key'),
+    "JWT_ISSUER": os.environ.get('JWT_ISSUER', 'http://127.0.0.1:8000/oauth2'),
+    "JWT_EXPIRATION_DELTA": int(os.environ.get('JWT_EXPIRATION_DELTA', 1)),
+    "JWT_SECRET_KEY": os.environ.get('JWT_SECRET_KEY', 'credentials-secret')
+}

--- a/credentials/locustfile.py
+++ b/credentials/locustfile.py
@@ -1,24 +1,135 @@
+from collections import deque
 import datetime
+import random
 import uuid
 
 import jwt
-from locust import TaskSet, task, HttpLocust
+from locust import task, HttpLocust
 from locust.clients import HttpSession
 from locust.exception import LocustError
 
 from helpers.api import LocustEdxRestApiClient
-from credentials.config import CREDENTIAL_API_URL, JWT_AUDIENCE, JWT_ISSUER, JWT_EXPIRATION_DELTA, JWT_SECRET_KEY
+from credentials.config import CREDENTIAL_API_URL, CREDENTIAL_SERVICE_URL, JWT, LMS_ROOT_URL, PROGRAM_ID
+from helpers.auto_auth_tasks import AutoAuthTasks
 
 
-class CredentialTaskSet(TaskSet):
+class CredentialTaskSet(AutoAuthTasks):
     """Tasks exercising Credential functionality."""
-    @task
-    def list_credential_with_username(self):
-        self.client.user_credentials.get(username="user1")
+
+    # Keep track of credential ids created during a test, so they can be used to formulate read requests, and patch
+    # requests. A deque is used instead of a list in order to enforce maximum length.
+    _user_credentials = deque(maxlen=1000)
+
+    def on_start(self):
+        self.user_credential_client = self.get_credential_client()
+
+    def get_credential_client(self):
+        """ New property added for using LocustEdxRestApiClient.
+        Default locust client will remain same for using auto_auth().
+        """
+        return LocustEdxRestApiClient(
+            CREDENTIAL_API_URL,
+            session=HttpSession(base_url=self.locust.host),
+            jwt=self._get_token()
+        )
+
+    def _get_token(self):
+        payload = {
+            'preferred_username': "load-test-" + uuid.uuid4().hex,
+            'iss': JWT["JWT_ISSUER"],
+            'aud': JWT["JWT_AUDIENCE"],
+            'iat': datetime.datetime.utcnow(),
+            'exp': datetime.datetime.utcnow() + datetime.timedelta(days=JWT["JWT_EXPIRATION_DELTA"]),
+            'administrator': True
+        }
+        return jwt.encode(payload, JWT["JWT_SECRET_KEY"])
 
     @task
-    def list_credential_with_username_and_status(self):
-        self.client.user_credentials.get(username="user1", status="awarded")
+    def list_user_credential_with_username(self):
+        """ Get all credentials for a user."""
+        self.user_credential_client.user_credentials.get(username="user1")
+
+    @task
+    def list_user_credential_with_username_and_status(self):
+        """ Get credentials having awarded status for a user."""
+        self.user_credential_client.user_credentials.get(username="user1", status="awarded")
+
+    @task
+    def list_program_credential_with_programs_id(self):
+        """ Get credentials of any any status for a program id."""
+        self.user_credential_client.program_credentials.get(program_id=PROGRAM_ID)
+
+    @task
+    def list_program_credential_with_program_id_and_status(self):
+        """ Get credentials having awarded status for a program id."""
+        self.user_credential_client.program_credentials.get(program_id=PROGRAM_ID, status="awarded")
+
+    @task
+    def post_credential_with_attribute(self):
+        # We are creating new user on LMS for generating its credentials,
+        # user information will be used in rendering of credentials.
+        self.auto_auth(hostname=LMS_ROOT_URL)
+        data = {
+            "username": self._username,
+            "credential": {"program_id": PROGRAM_ID},
+            "attributes": [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
+        }
+        user_credential = self.user_credential_client.user_credentials.post(
+            data=data,
+            name="/api/v1/user_credentials/(with_attributes)"
+        )
+        self._user_credentials.append((user_credential["id"], user_credential["uuid"]))
+
+    @task
+    def post_credential_without_attribute(self):
+        # We are creating new user on LMS for generating its credentials,
+        # user information will be used in rendering of credentials.
+        self.auto_auth(hostname=LMS_ROOT_URL)
+        data = {
+            "username": self._username,
+            "credential": {"program_id": PROGRAM_ID},
+            "attributes": []
+        }
+        user_credential = self.user_credential_client.user_credentials.post(
+            data=data,
+            name="/api/v1/user_credentials/(without_attributes)"
+        )
+        self._user_credentials.append((user_credential["id"], user_credential["uuid"]))
+
+    @task
+    def get_credential(self):
+        if not self._user_credentials:
+            return
+
+        credential_id = random.choice(self._user_credentials)[0]
+        self.user_credential_client.user_credentials(credential_id).get(name="/api/v1/user_credentials/[id]")
+
+    @task
+    def patch_credential(self):
+        """ Randomly picked the status for patching the credentials. In case of revoke status remove the
+        record from the deque. Otherwise during rendering task it will return 404.
+        """
+        if not self._user_credentials:
+            return
+
+        user_credentials = random.choice(self._user_credentials)
+        status = random.choice(["awarded", "revoked"])
+        data = {"status": status}
+        if status == "revoked":
+            self._user_credentials.remove(user_credentials)
+        self.user_credential_client.user_credentials(user_credentials[0]).patch(
+            data=data, name="/api/v1/user_credentials/[id]"
+        )
+
+    @task
+    def render_credential(self):
+        """ Render a user credential. """
+        if not self._user_credentials:
+            return
+
+        credential_uuid = random.choice(self._user_credentials)[1]
+        self.client.get("{}/credentials/{}/".format(CREDENTIAL_SERVICE_URL, credential_uuid.replace("-", "")),
+                        name="/credentials/[uuid]")
 
 
 class CredentialUser(HttpLocust):
@@ -29,10 +140,6 @@ class CredentialUser(HttpLocust):
     user should wait between executing tasks. This class also provides a custom client used
     to interface with edX REST APIs.
     """
-    # Django's AbstractUser, subclassed by Credentials, limits usernames to 30 characters.
-    # See: https://github.com/django/django/blob/stable/1.8.x/django/contrib/auth/models.py#L385
-    USERNAME_MAX_LENGTH = 30
-    USERNAME_PREFIX = 'load-test-'
 
     task_set = CredentialTaskSet
     min_wait = 30
@@ -46,23 +153,3 @@ class CredentialUser(HttpLocust):
                 'You must specify a base host, either in the host attribute in the Locust class, '
                 'or on the command line using the --host option.'
             )
-
-        self.client = LocustEdxRestApiClient(
-            CREDENTIAL_API_URL,
-            session=HttpSession(base_url=self.host),
-            jwt=self._get_token()
-        )
-
-    def _get_token(self):
-        # Keep the length of the resulting username within Django's prescribed limits.
-        username_suffix = uuid.uuid4().hex[:self.USERNAME_MAX_LENGTH - len(self.USERNAME_PREFIX)]
-
-        payload = {
-            'preferred_username': self.USERNAME_PREFIX + username_suffix,
-            'iss': JWT_ISSUER,
-            'aud': JWT_AUDIENCE,
-            'iat': datetime.datetime.utcnow(),
-            'exp': datetime.datetime.utcnow() + datetime.timedelta(days=JWT_EXPIRATION_DELTA),
-        }
-
-        return jwt.encode(payload, JWT_SECRET_KEY)


### PR DESCRIPTION
ECOM-3483

Added locust tasks for
* user credential `list` endpoint
* program credential `list` endpoint
* user credential `POST`, `GET` and `PATCH` requests.
* credential rendering

@awais786 @ahsan-ul-haq @zubair-arbi 