### PR TITLE
TNL-5023: Add seeding and testing of large thread.

### DIFF
--- a/lms/course_data/__init__.py
+++ b/lms/course_data/__init__.py
@@ -60,13 +60,6 @@ class CourseData(dict):
         return random.choice(self['sequential_ids'])
 
     @property
-    def discussion_id(self):
-        """
-        randomly choose the discussion_id of a discussion module (aka commentable_id)
-        """
-        return random.choice(self['discussion_ids'])
-
-    @property
     def html_usage_id(self):
         """
         randomly choose the usage_id of an HTML module
@@ -217,38 +210,6 @@ demo_course = CourseData(
         "OEoXaMPEzfM",
         "oX46YqHWgyw",
         "qWxm7CA2v24",
-    ),
-    discussion_ids=(  # from metadata.discussion_id, not the block id
-        "d9f970a42067413cbb633f81cfb12604",
-        "98d8feb5971041a085512ae22b398613",
-        "1d153da210844719a1a6cc39ca09673c",
-        "265ca2d808814d76ad670957a2b6071f",
-        "23347cb1d1e74ec79453ce361e38eb18",
-        "4250393f9f684bfeb3f1d514e15592d1",
-        "eb264c9899b745fc81cd7405b53a7a65",
-        "aecab8f355744782af5a9470185f0005",
-        "cba3e4cd91d0466b9ac50926e495b76f",
-        "ed3164d1235645739374094a8172964b",
-        "b770140a122741fea651a50362dee7e6",
-        "c49f0dfb8fc94c9c8d9999cc95190c56",
-        "53c486b035b4437c9197a543371e0f03",
-        "d7b66e45154b4af18f33213337685e91",
-        "9ad16580878f49d1bf20ce1bc533d16e",
-        "b11488e3580241f08146cbcfca693d06",
-        "bb15269287ec44b6a2f69447db43d845",
-        "239ef52e6eee468fb698b4217a7bafc6",
-        "cdad92273f7d4622aed770b7de8583bc",
-        "e4365aad2c39498d824cf984b3f9b083",
-        "6e51dd8f181b44ffa6d91303a287ed3f"
-        "edx_demo_embedded_discussion",
-        "31c83aefa6634e83a3c80b81f5447201",
-        "0717ec26e67e49b2a9f30d2e15c417dd",
-        "df0905ee484844769644f330844253e7",
-        "e252d4de97c7426e8b67ff516a9962f6",
-        "97f19f6202e54d6a9ea59f7a573725a1",
-        "d459fcb5792b459ca0aefe141e633ccc",
-        "ba12c2e0b81e4cef8e05e22049aafd63",
-        "a56e406f164746d8bbff76545e6d981f",
     ),
     courseware_paths=(
         '',

--- a/lms/locustfile.py
+++ b/lms/locustfile.py
@@ -19,7 +19,7 @@ import os
 from locust import HttpLocust
 
 from courseware_views import CoursewareViewsTasks
-from forums import ForumsTasks
+from forums import ForumsTasks, SeedForumsTasks
 from lms import LmsTasks
 from module_render import ModuleRenderTasks
 


### PR DESCRIPTION
### Description
 
[TNL-5023](https://openedx.atlassian.net/browse/TNL-5023)

TNL-5023: Forums Performance: Investigate Large Threads

Here is a first pass at seeding/testing large threads.  

This code adds a Locust Task Set for:

1. Seeding a large thread.
2. Reading the large thread.

The seeding was implemented as a Locust Task Set which can be run as a separate test.  This enables the seeding to take advantage of the parallelism of Locust, and we can also compare seeding times.

Here's how to seed:
```
BASIC_AUTH_USER=XXX BASIC_AUTH_PASSWORD=YYY COURSE_ID=course-v1:edX+DemoX+Demo_Course LOCUST_TASK_SET=SeedForumsTasks LOCUST_MIN_WAIT=1000 LOCUST_MAX_WAIT=1000 locust -c 10 -r 1 -n 4500 -H https://discussions.sandbox.edx.org --no-web
````

Testing against a large thread just does repeated reads:
```
BASIC_AUTH_USER=XXX BASIC_AUTH_PASSWORD=YYY LARGE_TOPIC_ID=i4x-edx-eiorguegnru-course-foobarbaz LARGE_THREAD_ID=579f8b6948ee34412e000078 COURSE_ID=course-v1:edX+DemoX+Demo_Course LOCUST_TASK_SET=ForumsTasks LOCUST_MIN_WAIT=1000 LOCUST_MAX_WAIT=1000 locust -c 10 -r 1 -H https://discussions.sandbox.edx.org --no-web
```

I'll drops some comments in the code as well.

### Reviewers (any 2 of the following):
- [x] @tobz 
- [x] @pwnage101 
- [ ] @ormsbee 
- [ ] @dianakhuang 

FYI: @andy-armstrong @bjacobel 

### Post-review
- [x] Squash commits
