### PR TITLE
MA-2696: load test new index for unread_comment_count

### DIFF
--- a/discussions_api/db/create_indexes.js
+++ b/discussions_api/db/create_indexes.js
@@ -259,6 +259,17 @@ var contentsIndexes = [
         "name" : "author_id_1_course_id_1",
         "ns" : "comments-prod.contents",
         "background" : true
+    },
+    {
+        "v" : 1,
+        "key" : {
+            "comment_thread_id" : 1,
+            "author_id" : 1,
+            "created_at" : 1
+        },
+        "ns" : "comments-prod.contents",
+        "name" : "comment_thread_id_1_author_id_1_created_at_1",
+        "background" : true
     }
 ];
 


### PR DESCRIPTION
[MA-2696](https://openedx.atlassian.net/browse/MA-2696)

Run load tests on a new index to calculate `unread_comment_count`.
`db.contents.ensureIndex({ comment_thread_id: 1, author_id: 1, created_at: 1 }, { background: true })`
