### PR TITLE
improve docs related to settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,20 +12,32 @@ If you have not already done so, create and activate a `virtualenv <https://virt
 
 Next, install load testing requirements.
 
-.. code-block:: bash
+.. code-block::
 
     $ pip install -r requirements.txt
 
+If the load test in question has additional requirements, install those too:
+
+.. code-block::
+
+    $ pip install -r <test-name>/requirements.txt (consult the <test-name> directory)
+
+Configure load test inputs. For example:
+
+.. code-block::
+
+    $ editor settings_files/<test-name>.yml
+
 Start Locust by providing the Locust CLI with a target host and pointing it to the location of your desired locustfile. For example,
 
-.. code-block:: bash
+.. code-block::
 
-    $ locust --host=http://localhost:8009 -f programs
+    $ locust --host=http://localhost:8009 -f <test-name>
 
 Repository Structure
 --------------------
 
-Tests are organized into top-level packages. For examples, see ``csm`` and ``programs``. A module called ``locustfile.py`` is included inside each test package, within which a subclass of the `Locust class <http://docs.locust.io/en/latest/writing-a-locustfile.html#the-locust-class>`_ is defined. This subclass is imported into the test package's ``__init__.py`` to facilitate discovery at runtime.  Settings for each test are stored under the ``settings_files`` directory; ``<testname>`` reads settings data from ``settings_files/<testname>.yml``.
+Tests are organized into top-level packages. For examples, see ``csm`` or ``enrollment``. A module called ``locustfile.py`` is included inside each test package, within which a subclass of the `Locust class <http://docs.locust.io/en/latest/writing-a-locustfile.html#the-locust-class>`_ is defined. This subclass is imported into the test package's ``__init__.py`` to facilitate discovery at runtime.  Settings for each test are stored under the ``settings_files`` directory; ``<testname>`` reads settings data from ``settings_files/<testname>.yml``.
 
 License
 -------
@@ -52,6 +64,7 @@ Please do not report security issues in public. Please email security@edx.org.
 Mailing List and IRC Channel
 ----------------------------
 
-You can discuss this code in the `edx-code Google Group`__ or in the ``#edx-code`` IRC channel on Freenode.
+You can discuss this code in the `edx-code Google Group` or in the ``#general`` slack channel.
 
-__ https://groups.google.com/forum/#!forum/edx-code
+* https://groups.google.com/forum/#!forum/edx-code
+* http://openedx-slack-invite.herokuapp.com/

--- a/discussions_api/README.rst
+++ b/discussions_api/README.rst
@@ -73,12 +73,13 @@ The following give an example of creating some threads, comments and responses.
 Running Load Test
 -----------------
 
-Run tests with something like:
+#. Update `settings_files/discussions_api.yml` with the provided COURSE_ID and
+   SEEDED_DATA output from seed_data.py script
+#. Run tests with something like:
 
 .. code-block:: bash
 
-    # Use COURSE_ID and SEEDED_DATA output from seed_data.py script
-    $ COURSE_ID=course-v1:testX+C1+2016_C1 SEEDED_DATA=GetCommentsTasks6 LOCUST_MIN_WAIT=1000 LOCUST_MAX_WAIT=1000 locust -f discussions_api -c 2 -r 10 -n 200 -H http://localhost:8000 --no-web
+    $ locust -f discussions_api -c 2 -r 10 -n 200 -H http://localhost:8000 --no-web
 
 
 Troubleshooting
@@ -88,7 +89,7 @@ If you see any authorization or other errors, you can `follow instructions in
 the wiki <https://openedx.atlassian.net/wiki/display/EdxOps/How+to+Run+Performance+Tests>`_.
 
 If you are getting CSRF Token errors that are not covered above, be sure to
-include environment variables BASIC_AUTH_USER=XXX BASIC_AUTH_PASSWORD=YYY if you
+include settings variables BASIC_AUTH_USER BASIC_AUTH_PASSWORD if you
 are running against a protected sandbox.
 
 If you are getting 500 errors, check that the comment service is up and running


### PR DESCRIPTION
Grok'd the READMEs for anything suggesting that we use the old style settings (environment variables) and updated it. Also:

* freenode -> slack
* show how to install custom requrements
* use something other than `programs` as an example (programs is being retired).