### PR TITLE
makefile works for all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,34 @@
-course_discovery:
-	locust --host=$(HOST) -f course_discovery
+# Update this list when you add a new test.
+TESTS = \
+    course_discovery \
+    course_import \
+    credentials \
+    csm \
+    discussions_api \
+    ecommerce \
+    enrollment \
+    lms \
+    teams_discussion
 
-.PHONY: course_discovery
+help:
+	@echo 'see README.rst for usage details'
+
+requirements:
+	pip install -r requirements.txt --exists-action w
+
+# I don't understand why the .SECONDEXPANSION feature needs to be enabled to
+# use $@ (target reference) in prerequisites, but it does.  Please help to
+# figure out a cleaner solution.
+.SECONDEXPANSION:
+
+# If the settings file is missing, just copy the example settings.  If the
+# settings file already exists, this recipe will not be triggered. Your custom
+# settings should never not be overwritten.
+settings_files/%.yml: $$@.example
+	cp $< $@
+
+$(TESTS): settings_files/$$@.yml
+	locust --host=$(HOST) -f $@
+
+.PHONY: help requirements $(TESTS)
+.DEFAULT: help

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Next, install load testing requirements.
 
 .. code-block::
 
-    $ pip install -r requirements.txt
+    $ make requirements
 
 If the load test in question has additional requirements, install those too:
 
@@ -29,11 +29,17 @@ Configure load test inputs. For example:
     $ cp settings_files/<test-name>.yml.example settings_files/<test-name>.yml
     $ editor settings_files/<test-name>.yml
 
-Start Locust by providing the Locust CLI with a target host and pointing it to the location of your desired locustfile. For example,
+Start Locust by a target host and the name of your test. For example,
 
 .. code-block::
 
-    $ locust --host=http://localhost:8009 -f <test-name>
+    $ HOST=http://localhost:8009 make <test-name>
+
+You can also provide extra arguments by invoking locust directly:
+
+.. code-block::
+
+    $ locust --host=http://localhost:8009 -f <test-name> --no-web --clients=20 --hatch-rate=2
 
 Repository Structure
 --------------------


### PR DESCRIPTION
* also add make targets for the settings files
* also add "requirements" make taget

---

some examples:
```
$ make requirements
pip install -r requirements.txt --exists-action w
Downloading/unpacking edx-opaque-keys==0.3.2 (from -r requirements/base.txt (line 1))
  Downloading edx-opaque-keys-0.3.2.tar.gz
...
```

```
$ HOST=http://localhost:8009 make enrollment
locust --host=http://localhost:8009 -f enrollment
[2016-08-24 17:10:15,826] carbon/INFO/helpers.settings: using settings file: /home/tsankey/tmp/edx-load-tests/edx-load-tests/settings_files/enrollment.yml
[2016-08-24 17:10:15,827] carbon/INFO/helpers.settings: loaded the following settings:
...
```
```
$ make
see README.rst for usage details
```