### PR TITLE
implement the @interrupt_task (was @peek) decorator

### DIFF
--- a/helpers/interrupt_after.py
+++ b/helpers/interrupt_after.py
@@ -1,0 +1,48 @@
+"""
+This file defines the interrupt_after decorator for locusts tasks.
+
+If your load test only has one TaskSet, ignore this utility.  Else, read on...
+
+Normally the locust client gets captured by a TaskSet class, preventing it from
+escaping to run tasks in sibling TaskSet classes unless it explicitly runs a
+task which calls the interrupt() function.  This interrupt_after decorator is
+simply a tool for calling the interrupt() function safely.
+
+If it is not detrimental to the load test results to have locust users hopping
+between TaskSets, you should consider using the interrupt_after decorator on
+all tasks of all TaskSets in your load test.  For small numbers of locust
+clients (especially when the test target is a load balancer) this will
+generally help keep the transaction distribution even.
+"""
+
+
+def is_root(task_set):
+    """
+    Return True if task_set is a root TaskSet instance, which means that it has
+    been called directly from the Locust class and so it has no parent.
+    """
+    # use `is` instead of `==` for reference equality
+    return task_set.parent is task_set.locust
+
+
+def interrupt_after(func):
+    """
+    Decorator for a locust task which causes it to be the last task to be
+    scheduled in the current TaskSet, unless the current TaskSet is the root
+    TaskSet---in the latter case this decorator is a no-op.
+
+    Use after the @task decorator:
+
+        @task(21)
+        @interrupt_after
+        def some_task(self): ...
+
+    """
+    def _interrupt_after(self, *args, **kwargs):
+        func(self, *args, **kwargs)
+        # Before interrupting, make sure that there is a parent task set to
+        # escape to.  Otherwise locust will crash.
+        if not is_root(self):
+            self.interrupt()
+
+    return _interrupt_after

--- a/loadtests/lms/courseware_views.py
+++ b/loadtests/lms/courseware_views.py
@@ -1,4 +1,5 @@
 from locust import task
+from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -23,6 +24,7 @@ class CoursewareViewsTasks(LmsTasks):
     """
 
     @task(50)
+    @interrupt_after
     def index(self):
         """
         Request a randomly-chosen top-level page in the course.
@@ -31,6 +33,7 @@ class CoursewareViewsTasks(LmsTasks):
         self.get(path, name='courseware:index')
 
     @task(33)
+    @interrupt_after
     def mktg_course_about(self):
         """
         Request the marketing about view (rendered as a button in the marketing site).
@@ -38,6 +41,7 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('mktg-about', name='courseware:mktg_course_about')
 
     @task(10)
+    @interrupt_after
     def info(self):
         """
         Request the course info tab.
@@ -45,6 +49,7 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('info', name='courseware:course_info')
 
     @task(4)
+    @interrupt_after
     def progress(self):
         """
         Request the progress tab.
@@ -52,6 +57,7 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('progress', name='courseware:progress')
 
     @task(1)
+    @interrupt_after
     def about(self):
         """
         Request the LMS' internal about page for this course.

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -8,6 +8,7 @@ from lazy import lazy
 from base import LmsTasks
 from locust import task
 
+from helpers.interrupt_after import interrupt_after
 from helpers import settings
 
 logging.basicConfig(level=logging.INFO)
@@ -184,6 +185,7 @@ class ForumsTasks(BaseForumsTasks):
 
     """
     @task(10)
+    @interrupt_after
     def forum_form_discussion(self):
         """
         Visit the discussion tab.
@@ -191,6 +193,7 @@ class ForumsTasks(BaseForumsTasks):
         self.get('discussion/forum', name="forums:forum_form_discussion")
 
     @task(4)
+    @interrupt_after
     def search_topic(self):
         """
         Load a randomly-selected topic from the discussion tab sidebar.
@@ -206,6 +209,7 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(10)
+    @interrupt_after
     def inline_discussion(self):
         """
         Load a randomly-selected inline discussion.
@@ -217,6 +221,7 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(4)
+    @interrupt_after
     def create_thread(self):
         """
         create a new thread in a randomly-selected topic
@@ -225,6 +230,7 @@ class ForumsTasks(BaseForumsTasks):
         ForumsTasks._thread_ids.append(thread)
 
     @task(36)
+    @interrupt_after
     def single_thread(self):
         """
         Read a specific thread.
@@ -243,6 +249,7 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(23)
+    @interrupt_after
     def large_thread(self):
         """
         Read the large thread.
@@ -255,6 +262,7 @@ class ForumsTasks(BaseForumsTasks):
             self.single_thread()
 
     @task(4)
+    @interrupt_after
     def create_response(self):
         """
         Post a response to an existing thread.
@@ -267,6 +275,7 @@ class ForumsTasks(BaseForumsTasks):
         super(ForumsTasks, self).create_response(thread_id)
 
     @task(1)
+    @interrupt_after
     def user_profile(self):
         """
         Request the user profile endpoint.
@@ -277,6 +286,7 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(1)
+    @interrupt_after
     def followed_threads(self):
         """
         Request the followed threads endpoint.
@@ -316,6 +326,7 @@ class SeedForumsTasks(BaseForumsTasks):
     _large_thread_response_ids = deque(maxlen=100)
 
     @task(10)
+    @interrupt_after
     def create_response(self):
         """
         Post a response to an existing thread.
@@ -335,6 +346,7 @@ class SeedForumsTasks(BaseForumsTasks):
             SeedForumsTasks._large_thread_response_ids.append(response_id)
 
     @task(1)
+    @interrupt_after
     def create_comment(self):
         """
         Post a response to an existing thread.

--- a/loadtests/lms/module_render.py
+++ b/loadtests/lms/module_render.py
@@ -2,6 +2,7 @@ import random
 import re
 
 from locust import task
+from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -71,6 +72,7 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(13)
+    @interrupt_after
     def goto_position(self):
         """
         POST to goto_position in our course, using random inputs based on course data.
@@ -82,34 +84,39 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(22)
+    @interrupt_after
     def capa_problem_get(self):
         """
         Exercise the problem_get handler.
         """
-        return self._post_capa_handler('problem_get')
+        self._post_capa_handler('problem_get')
 
     @task(2)
+    @interrupt_after
     def capa_problem_show(self):
         """
         Exercise the problem_show handler.
         """
-        return self._post_capa_handler('problem_show')
+        self._post_capa_handler('problem_show')
 
     @task(8)
+    @interrupt_after
     def capa_problem_check(self):
         """
         Exercise the problem_check handler.
         """
-        return self._post_capa_handler('problem_check')
+        self._post_capa_handler('problem_check')
 
     @task(1)
+    @interrupt_after
     def capa_problem_save(self):
         """
         Exercise the problem_save handler.
         """
-        return self._post_capa_handler('problem_save')
+        self._post_capa_handler('problem_save')
 
     @task(9)
+    @interrupt_after
     def get_transcript(self):
         """
         Exercises transcript retrieval, using random inputs based on course data.
@@ -121,6 +128,7 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(20)
+    @interrupt_after
     def save_user_state(self):
         """
         Exercises user state persistence, using random inputs based on course data.

--- a/loadtests/lms/wiki_views.py
+++ b/loadtests/lms/wiki_views.py
@@ -1,5 +1,6 @@
 from random import randint
 from locust import task
+from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -13,6 +14,7 @@ class WikiViewTask(LmsTasks):
     """
 
     @task
+    @interrupt_after
     def view_article(self):
         """
         Request one of the articles known to exist.


### PR DESCRIPTION
This decorator turns a normal locust task into one which greedily
interrupts (to interrupt from a task means to stop scheduling tasks from
the current TaskSet instance and change context to one TaskSet level up)

---

@robrap this is more or less complete, sans documentation.  it's late on friday, so I figured i'd just post it up and see what you think so far.