### PR TITLE
locust task ratios can only be integers

### DIFF
--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -136,8 +136,8 @@ class LmsTest(LmsTasks):
     tasks = {
         CoursewareViewsTasks: 5,
         ForumsTasks: 1,
-        ModuleRenderTasks: 22 * float(settings.data.get('MODULE_RENDER_MODIFIER', 1)),
-        ProctoredExamTasks: 1 * float(settings.data.get('PROCTORED_EXAM_MODIFIER', 1)),
+        ModuleRenderTasks: int(round(22 * float(settings.data.get('MODULE_RENDER_MODIFIER', 1)))),
+        ProctoredExamTasks: int(round(1 * float(settings.data.get('PROCTORED_EXAM_MODIFIER', 1)))),
         TrackingTasks: 24,
     }
 


### PR DESCRIPTION
Before this commit, the LMS loadtest would just crash on my machine.
Locust does not appear to tolerate float ratios.

---

@dianakhuang 