### PR TITLE
Update requirements for locust version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # should import this file.
 
 # load testing software
-locustio==0.7.3
+locustio==0.7.5
 
 # common loadtest requirements
 edx-opaque-keys==0.3.3


### PR DESCRIPTION
ECOM-6711
@edx/ecommerce

Updated requirements to use locust 0.7.5 instead of 0.7.3.