### PR TITLE
[lms] remove all interrupt_after calls

### DIFF
--- a/helpers/interrupt_after.py
+++ b/helpers/interrupt_after.py
@@ -1,6 +1,11 @@
 """
 This file defines the interrupt_after decorator for locusts tasks.
 
+WARNING: This decorator currently does not function correctly since it causes
+on_start to run after every reqeust.  on_start normally contains setup code
+such as auto_auth and enrollment.  Do not use this decorator until this bug is
+fixed.
+
 If your load test only has one TaskSet, ignore this utility.  Else, read on...
 
 Normally the locust client gets captured by a TaskSet class, preventing it from
@@ -43,6 +48,6 @@ def interrupt_after(func):
         # Before interrupting, make sure that there is a parent task set to
         # escape to.  Otherwise locust will crash.
         if not is_root(self):
-            self.interrupt()
+            self.interrupt(False)  # False parameter forces locust to enter wait
 
     return _interrupt_after

--- a/loadtests/lms/courseware_views.py
+++ b/loadtests/lms/courseware_views.py
@@ -1,5 +1,4 @@
 from locust import task
-from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -24,7 +23,6 @@ class CoursewareViewsTasks(LmsTasks):
     """
 
     @task(50)
-    @interrupt_after
     def index(self):
         """
         Request a randomly-chosen top-level page in the course.
@@ -33,7 +31,6 @@ class CoursewareViewsTasks(LmsTasks):
         self.get(path, name='courseware:index')
 
     @task(33)
-    @interrupt_after
     def mktg_course_about(self):
         """
         Request the marketing about view (rendered as a button in the marketing site).
@@ -41,7 +38,6 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('mktg-about', name='courseware:mktg_course_about')
 
     @task(10)
-    @interrupt_after
     def info(self):
         """
         Request the course info tab.
@@ -49,7 +45,6 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('info', name='courseware:course_info')
 
     @task(4)
-    @interrupt_after
     def progress(self):
         """
         Request the progress tab.
@@ -57,7 +52,6 @@ class CoursewareViewsTasks(LmsTasks):
         self.get('progress', name='courseware:progress')
 
     @task(1)
-    @interrupt_after
     def about(self):
         """
         Request the LMS' internal about page for this course.

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -8,7 +8,6 @@ from lazy import lazy
 from base import LmsTasks
 from locust import task
 
-from helpers.interrupt_after import interrupt_after
 from helpers import settings
 
 logging.basicConfig(level=logging.INFO)
@@ -185,7 +184,6 @@ class ForumsTasks(BaseForumsTasks):
 
     """
     @task(10)
-    @interrupt_after
     def forum_form_discussion(self):
         """
         Visit the discussion tab.
@@ -193,7 +191,6 @@ class ForumsTasks(BaseForumsTasks):
         self.get('discussion/forum', name="forums:forum_form_discussion")
 
     @task(4)
-    @interrupt_after
     def search_topic(self):
         """
         Load a randomly-selected topic from the discussion tab sidebar.
@@ -209,7 +206,6 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(10)
-    @interrupt_after
     def inline_discussion(self):
         """
         Load a randomly-selected inline discussion.
@@ -221,7 +217,6 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(4)
-    @interrupt_after
     def create_thread(self):
         """
         create a new thread in a randomly-selected topic
@@ -230,7 +225,6 @@ class ForumsTasks(BaseForumsTasks):
         ForumsTasks._thread_ids.append(thread)
 
     @task(36)
-    @interrupt_after
     def single_thread(self):
         """
         Read a specific thread.
@@ -249,7 +243,6 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(23)
-    @interrupt_after
     def large_thread(self):
         """
         Read the large thread.
@@ -262,7 +255,6 @@ class ForumsTasks(BaseForumsTasks):
             self.single_thread()
 
     @task(4)
-    @interrupt_after
     def create_response(self):
         """
         Post a response to an existing thread.
@@ -275,7 +267,6 @@ class ForumsTasks(BaseForumsTasks):
         super(ForumsTasks, self).create_response(thread_id)
 
     @task(1)
-    @interrupt_after
     def user_profile(self):
         """
         Request the user profile endpoint.
@@ -286,7 +277,6 @@ class ForumsTasks(BaseForumsTasks):
         )
 
     @task(1)
-    @interrupt_after
     def followed_threads(self):
         """
         Request the followed threads endpoint.
@@ -326,7 +316,6 @@ class SeedForumsTasks(BaseForumsTasks):
     _large_thread_response_ids = deque(maxlen=100)
 
     @task(10)
-    @interrupt_after
     def create_response(self):
         """
         Post a response to an existing thread.
@@ -346,7 +335,6 @@ class SeedForumsTasks(BaseForumsTasks):
             SeedForumsTasks._large_thread_response_ids.append(response_id)
 
     @task(1)
-    @interrupt_after
     def create_comment(self):
         """
         Post a response to an existing thread.

--- a/loadtests/lms/module_render.py
+++ b/loadtests/lms/module_render.py
@@ -2,7 +2,6 @@ import random
 import re
 
 from locust import task
-from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -274,7 +273,6 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(16)
-    @interrupt_after
     def goto_position(self):
         """
         POST to goto_position in our course, using random inputs based on course data.
@@ -286,7 +284,6 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(1)
-    @interrupt_after
     def capa_problem_get(self):
         """
         Exercise the problem_get handler.
@@ -294,7 +291,6 @@ class ModuleRenderTasks(LmsTasks):
         self._post_capa_handler('problem_get')
 
     @task(2)
-    @interrupt_after
     def capa_problem_show(self):
         """
         Exercise the problem_show handler.
@@ -302,7 +298,6 @@ class ModuleRenderTasks(LmsTasks):
         self._post_capa_handler('problem_show')
 
     @task(10)
-    @interrupt_after
     def capa_problem_check(self):
         """
         Exercise the problem_check handler.
@@ -310,7 +305,6 @@ class ModuleRenderTasks(LmsTasks):
         self._post_capa_handler('problem_check')
 
     @task(1)
-    @interrupt_after
     def capa_problem_save(self):
         """
         Exercise the problem_save handler.
@@ -318,7 +312,6 @@ class ModuleRenderTasks(LmsTasks):
         self._post_capa_handler('problem_save')
 
     @task(30)
-    @interrupt_after
     def get_transcript(self):
         """
         Exercises transcript retrieval, using random inputs based on course data.
@@ -330,7 +323,6 @@ class ModuleRenderTasks(LmsTasks):
         )
 
     @task(22)
-    @interrupt_after
     def save_user_state(self):
         """
         Exercises user state persistence, using random inputs based on course data.

--- a/loadtests/lms/wiki_views.py
+++ b/loadtests/lms/wiki_views.py
@@ -1,6 +1,5 @@
 from random import randint
 from locust import task
-from helpers.interrupt_after import interrupt_after
 
 from base import LmsTasks
 
@@ -14,7 +13,6 @@ class WikiViewTask(LmsTasks):
     """
 
     @task
-    @interrupt_after
     def view_article(self):
         """
         Request one of the articles known to exist.


### PR DESCRIPTION
interrupt()ing after every request causes locust to re-run on_start(),
causing the number of auto_auth and enroll transactions to shoot up.
This is worse than not using the decorator so we just remove it for
now.

This commit also fixes another bug with the decorator: force locust to
obey the wait/delay period after calling interrupt().

---
 @dianakhuang 