### PR TITLE
Pin gevent version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@
 # should import this file.
 
 # load testing software
+gevent==1.0.2
 locustio==0.7.5
 pyzmq==15.2.0  # needed for distributed mode. remove after we start using locustio>=8.0
 


### PR DESCRIPTION
Aha!

It turns out that, in a fresh virtualenv, the newly-updated version 0.7.5 of locustio will ask for gevent==1.1.1 to be installed. This version of gevent breaks something related to socket I/O for our use case (throws a low-level segfault). I was able to sidestep this issue by pinning gevent to a specific version (one that was already globally installed on my machine).

@pwnage101, any objections to this?