### PR TITLE
[lms] drive load against multiple courses

### DIFF
--- a/helpers/util.py
+++ b/helpers/util.py
@@ -1,0 +1,39 @@
+"""
+Generally helpful utilities for edx load testing.
+"""
+from random import random
+
+
+def choice_with_distribution(element_ratio_pairs):
+    """
+    Randomly choose an element with probabilities given by ratios.
+
+    This utility function takes a mapping of elements to ratios and chooses an
+    element with probability proportional to the corresponding ratio.  The
+    ratios do not need to add up to 1.0.
+
+    Args:
+        element_ratio_pairs (list): List of two-tuples containing the element
+            and its ratio (int or float).  E.g. [('hello', 12), ('world', 20)]
+
+    Returns:
+        An element (the first item in one of the given tuples)
+
+    Raises:
+        ValueError: If the input list is empty.
+        RuntimeError: If there is a bug in this function which causes no
+            element to get chosen.
+    """
+    if not element_ratio_pairs:
+        raise ValueError('element_ratio_pairs is empty.')
+    ratios_sum = sum(pair[1] for pair in element_ratio_pairs)
+    random_variable = random()  # possible values are [0.0, 1.0)
+    # The element is chosen based on iteratively decreasing the random variable
+    # by the normalized ratio of each element until it becomes negative.
+    for elem, ratio in element_ratio_pairs:
+        ratio_normalized = float(ratio) / ratios_sum
+        random_variable -= ratio_normalized
+        if random_variable < 0:
+            return elem
+    raise RuntimeError(
+        "Exited element selection loop without making a selection.")

--- a/loadtests/lms/base.py
+++ b/loadtests/lms/base.py
@@ -4,12 +4,14 @@
 import logging
 import os
 import sys
+import random
 
 from lazy import lazy
 from opaque_keys.edx.keys import CourseKey
 
 from helpers.auto_auth_tasks import AutoAuthTasks
 from helpers import settings
+from helpers import util
 
 import course_data
 
@@ -23,8 +25,17 @@ class EdxAppTasks(AutoAuthTasks):
     def course_id(self):
         """
         The complete id of the course we're configured to test with.
+
+        This function is evaluated once per locust client and its return value
+        is cached on a per-client basis (due to the @lazy decorator).  It
+        randomly selects a course from the "courses" dict specified in the
+        settings file.  The "ratio" keys of every course are used to construct
+        a probability distribution.
         """
-        return settings.data['COURSE_ID']
+        courses = settings.data['courses']
+        course_ratio_pairs = \
+            [(cid, cdata['ratio']) for cid, cdata in courses.iteritems()]
+        return util.choice_with_distribution(course_ratio_pairs)
 
     @lazy
     def course_key(self):
@@ -59,8 +70,21 @@ class EdxAppTasks(AutoAuthTasks):
         """
         Accessor for the CourseData instance we're configured to test with.
         """
-        course_data_name = settings.data['COURSE_DATA']
+        course_data_name = self._get_course_setting('course_data')
         return getattr(course_data, course_data_name)
+
+    def _get_course_setting(self, setting):
+        """
+        Accessor for a setting specific to the current course.
+
+        Args:
+            setting (str): name of course-specific setting
+
+        Raises:
+            KeyError: If the setting was not specified for this locust client's
+                selected course_id.
+        """
+        return settings.data['courses'][self.course_id][setting]
 
     @property
     def post_headers(self):

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -72,7 +72,10 @@ class BaseForumsTasks(LmsTasks):
         if BaseForumsTasks._large_thread:
             return BaseForumsTasks._large_thread[0]
         else:
-            return settings.data.get('LARGE_TOPIC_ID')
+            try:
+                return self._get_course_setting('large_topic_id')
+            except KeyError:
+                return None
 
     @lazy
     def large_thread_id(self):
@@ -82,7 +85,10 @@ class BaseForumsTasks(LmsTasks):
         if BaseForumsTasks._large_thread:
             return BaseForumsTasks._large_thread[1]
         else:
-            return settings.data.get('LARGE_THREAD_ID')
+            try:
+                return self._get_course_setting('large_thread_id')
+            except KeyError:
+                return None
 
     def create_thread(self, topic_id, name):
         """

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -19,8 +19,7 @@ from tracking import TrackingTasks
 
 from helpers import settings
 settings.init(__name__, required_data=[
-    'COURSE_ID',
-    'COURSE_DATA',
+    'courses',
     'LOCUST_TASK_SET',
     'LOCUST_MIN_WAIT',
     'LOCUST_MAX_WAIT',

--- a/settings_files/lms.yml.example
+++ b/settings_files/lms.yml.example
@@ -1,21 +1,28 @@
 ---
-# Course ID that we're running these tests against.  The default
-# targets a course which currently exists on courses-loadtest.edx.org.
-COURSE_ID: edX/DemoX/Demo_Course
+# The courses defines all the courses which will have load driven
+# against.  The keys at the top level are course IDs, and each value contains
+# some loadtesting-related metadata about the course.
+courses:
+    # This course currently exists on courses-loadtest.edx.org
+    edX/DemoX/Demo_Course:
+        # The name of the python object (must be defined in
+        # loadtests.lms.course_data) which contains course data specific to
+        # this course.
+        course_data: demo_course
 
-# The name of the course data variable which corresponds to the
-# COURSE_ID specified above.  Must be defined in the lms.course_data
-# module.
-COURSE_DATA: demo_course
+        # This ratio describes the relative amount of hatched locust clients to enroll
+        # and participate in this course.
+        ratio: 1
+
+        # Optionally provide a pointer to a large thread which you seeded using the
+        # SeedForumsTasks task set.  This thread will be used in addition to a
+        # small thread which will be automatically created.
+        #large_topic_id:
+        #large_thread_id:
 
 # Run the specified TaskSet (must be imported into the lms/locustfile.py
 # file):
 LOCUST_TASK_SET: LmsTest
-
-# Optionally provide a pointer to a large thread which you seeded using the
-# SeedForumsTasks task set:
-#LARGE_TOPIC_ID:
-#LARGE_THREAD_ID:
 
 # Used to determine how 'active' users are in timed and proctored exams.
 # This is the multiplying factor for how often proctoring-specific tasks happen (default is 1):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,22 @@
+"""Test functions in helpers.util"""
+
+import pytest
+from helpers.util import choice_with_distribution
+
+
+def test_choice_with_distribution():
+    """
+    Make sure that choice_with_distributions basically doesn't crash, and has
+    the correct type of return value.  However, do not test the distribution of
+    return values unless we are certain of the value.
+
+    The goal with this test is to NOT allow randomness to influence the result.
+    """
+    assert isinstance(choice_with_distribution([('a', 1), ('b', 2), ('c', 3)]), type('d'))
+    assert choice_with_distribution([('a', 1), ('b', 2), ('c', 3)]) in ['a', 'b', 'c']
+    assert choice_with_distribution([('a', 0), ('b', 0), ('c', 1)]) == 'c'
+    assert choice_with_distribution([('a', 0), ('b', 0), ('c', 0.5)]) == 'c'
+    assert choice_with_distribution([('a', 1)]) == 'a'
+    assert choice_with_distribution([('a', 0.5)]) == 'a'
+    with pytest.raises(ValueError):
+        choice_with_distribution([])


### PR DESCRIPTION
This allows multiple courses to be specified in settings like such:

```yaml
courses:
    edX/DemoX/Demo_Course:
        course_data: demo_course
        ratio: 5
    course-v1:edX+DemoX+Demo_Course:
        course_data: demo_course_split
        ratio: 3
...
```

Note that the locust summary of response times broken out by request type is the aggregate of all courses.  A possible PR for the future would additionally break out locust results by course.

@ormsbee