### PR TITLE
Implement util/merge_settings.py script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test : clean
 	py.test -n auto tests
 
 quality :
-	pep8 --config=.pep8 helpers loadtests tests
+	pep8 --config=.pep8 helpers loadtests tests util
 
 validate : quality test
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,6 @@ lazy
 dogapi==1.2.1
 edx-rest-api-client==1.7.1
 PyYAML==3.12
+
+# utility scripts use these
+click

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,7 @@ setup(
     package_data={
         'settings_files': ['*.yml'],
     },
+    entry_points = {
+        'console_scripts': ['merge_settings=util.merge_settings:main'],
+    },
 )

--- a/util/lms_module_render_tx_distribution.py
+++ b/util/lms_module_render_tx_distribution.py
@@ -28,39 +28,46 @@ import sys
 import fileinput
 import csv
 
-# fileinput takes input data from stdin or the filename in the first argument
-data = csv.reader(fileinput.input())
 
-# Set aside the first row, since it isn't data.  We'll use it to infer field
-# indexes.
-fields = next(data)
+def main():
 
-if 'Count' not in fields:
-    raise Exception('Count field not found')
-if 'Action' not in fields:
-    raise Exception('Action field not found')
+    # fileinput takes input data from stdin or the filename in the first argument
+    data = csv.reader(fileinput.input())
 
-# we're only concerned about the Count and Action fields
-count_idx = fields.index('Count')
-action_idx = fields.index('Action')
+    # Set aside the first row, since it isn't data.  We'll use it to infer field
+    # indexes.
+    fields = next(data)
 
-# filter out irrelevant data
-data = filter(
-    lambda record: record[action_idx].startswith('/XBlock/Handler'),
-    data
-)
+    if 'Count' not in fields:
+        raise Exception('Count field not found')
+    if 'Action' not in fields:
+        raise Exception('Action field not found')
 
-# sort by count
-data_sorted = sorted(data, key=lambda record: float(record[count_idx]), reverse=True)
+    # we're only concerned about the Count and Action fields
+    count_idx = fields.index('Count')
+    action_idx = fields.index('Action')
 
-# the total count is used to help normalize counts to percentages
-total_count = sum((float(record[count_idx]) for record in data_sorted))
+    # filter out irrelevant data
+    data = filter(
+        lambda record: record[action_idx].startswith('/XBlock/Handler'),
+        data
+    )
 
-# extract relevant fields and format/normalize them appropriately
-count_data_formatted = (
-    [record[action_idx], '{:.2f}%'.format(100 * float(record[count_idx]) / total_count)]
-    for record in data_sorted
-)
+    # sort by count
+    data_sorted = sorted(data, key=lambda record: float(record[count_idx]), reverse=True)
 
-# display results on stdout in CSV format
-csv.writer(sys.stdout).writerows(count_data_formatted)
+    # the total count is used to help normalize counts to percentages
+    total_count = sum((float(record[count_idx]) for record in data_sorted))
+
+    # extract relevant fields and format/normalize them appropriately
+    count_data_formatted = (
+        [record[action_idx], '{:.2f}%'.format(100 * float(record[count_idx]) / total_count)]
+        for record in data_sorted
+    )
+
+    # display results on stdout in CSV format
+    csv.writer(sys.stdout).writerows(count_data_formatted)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/util/merge_settings.py
+++ b/util/merge_settings.py
@@ -1,0 +1,41 @@
+"""
+Merge an arbitrary number of settings files ordered by priority.
+
+This script will generate a new settings yaml file and write it to standard
+output.  The files are ordered on the command line from lowest priority to
+highest priority, where higher priority settings override lower priority ones.
+
+Usage:
+
+    pip install -e .  # from the root of edx-load-tests
+    merge_settings settings_1.yml settings_2.yml ... settings_N.yml > merged.yml
+
+Keys present in settings_N.yml are guaranteed to appear in the output file
+because it has the highest priority.
+"""
+
+import sys
+import click
+from helpers.settings import Settings
+
+
+@click.command()
+@click.argument('settings_files', type=click.File(), nargs=-1)
+def main(settings_files):
+    """
+    The only command, and main entry point for this script.
+
+    Arguments:
+        settings_files (tuple of file objects):
+            The file objects refer to settings files.  The files (tuple
+            elements) are ordered from lowest to highest priority.
+    """
+    if len(settings_files) == 1:
+        # Only one filename was given on the command line, so we might as well
+        # preserve any comments by copying directly to stdout
+        sys.stdout.write(settings_files[0].read())
+    else:
+        merged_settings = Settings()
+        for settings_file in settings_files:
+            merged_settings.update(Settings.from_file(settings_file))
+        merged_settings.dump(sys.stdout)


### PR DESCRIPTION
This new script combines multiple settings files given on its arguments.
It will be useful for separating public settings from secrets.  It will
also be useful for passing YAML overrides via jenkins.

---

PR notes:

Nothing currently calls this script, but this unblocks my work on the next ticket about creating a new locust jenkins job DSL, where I'll be able to use this script to do all those things stated above (settings and overrides).

Example usage:

```
$ cat settings_files/example_1.yml
---
SETTING_1: old
SETTING_2: old
---
# secrets below
PASSWORD: # REQUIRED

$ cat settings_files/example_2.yml
---
SETTING_2: new
---
# secrets below
PASSWORD: super-duper-secret

$ util/merge_settings.py settings_files/example_1.yml settings_files/example_2.yml
---
SETTING_1: old
SETTING_2: new
---
PASSWORD: super-duper-secret
```

I did also evaluate a version of this script which preserved dict subkeys, but eventually decided against it because it introduced complexity which I couldn't justify, and was hard to describe/understand the merging process.  That branch still lives: https://github.com/edx/edx-load-tests/tree/pwnage101/perf-392

PERF-392