### PR TITLE
Add new course home page to the lms tests.

### DIFF
--- a/loadtests/lms/courseware_views.py
+++ b/loadtests/lms/courseware_views.py
@@ -30,6 +30,13 @@ class CoursewareViewsTasks(LmsTasks):
         path = 'courseware' + self.course_data.courseware_path
         self.get(path, name='courseware:index')
 
+    @task(10)
+    def course_home(self):
+        """
+        Requests the main course home page that contains the course outline.
+        """
+        self.get('course', name='courseware:course_home')
+
     @task(33)
     def mktg_course_about(self):
         """

--- a/loadtests/lms/courseware_views.py
+++ b/loadtests/lms/courseware_views.py
@@ -37,13 +37,6 @@ class CoursewareViewsTasks(LmsTasks):
         """
         self.get('course', name='courseware:course_home')
 
-    @task(33)
-    def mktg_course_about(self):
-        """
-        Request the marketing about view (rendered as a button in the marketing site).
-        """
-        self.get('mktg-about', name='courseware:mktg_course_about')
-
     @task(10)
     def info(self):
         """


### PR DESCRIPTION
We have simply added a new page.  None of the older pages need to be removed.

I noticed that we also had an older task for a page that no longer exists and is not used for anything, so I have removed it.