### PR TITLE
   Add an entry point for automatic load tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,7 @@ setup(
     entry_points = {
         'console_scripts': ['merge_settings=util.merge_settings:main'],
     },
+    # minimal set of requirements only corresponding to the scripts in
+    # entry_points.
+    install_requires=["click", "PyYAML",],
 )

--- a/util/jenkins-common.sh
+++ b/util/jenkins-common.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+###############################################################################
+#
+# jenkins-common.sh
+#
+# Common setup routine for running a loadtest in a jenkins job.
+#
+# Assumptions:
+# * The file $HOME/edx-venv_clean.tar.gz has been prepared, but not created
+#   within the sequence of build steps for this job.  It needs to have been
+#   created outside of the timeline of this jenkins job so that the human who
+#   started the build doesn't have to wait so long for the requirements to
+#   install.
+#
+###############################################################################
+
+# Reset the jenkins worker's virtualenv back to the
+# state it was in when the instance was spun up.
+if [ -e $HOME/edx-venv_clean.tar.gz ]; then
+    rm -rf $HOME/edx-venv
+    tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
+fi
+
+# Activate the Python virtualenv
+source $HOME/edx-venv/bin/activate
+
+echo "This node is `curl http://169.254.169.254/latest/meta-data/hostname`"

--- a/util/run-loadtest.sh
+++ b/util/run-loadtest.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+###############################################################################
+#
+# run-loadtest.sh
+#
+# Start a parameterized loadtest. This script is designed to be the entry
+# point for various automation systems (jenkins is currently supported).
+#
+# Assumptions:
+# * The assumptions made by util/${AUTOMATION_TOOL}-common.sh are also
+#   fulfilled, if you are using ${AUTOMATION_TOOL}.
+# * This script is invoked from the root of the edx-load-tests repo.
+# * The required environment variables are defined.
+# * pip is available.
+#
+# Required environment variables:
+# * TARGET_URL: The target to load test.
+# * TEST_COMPONENT: Which component of the target to load test.
+# * NUM_CLIENTS: The number of locust clients to hatch.
+# * HATCH_RATE: Hatches per second during locust ramp-up.
+#
+# Optional environment variables:
+# * MAX_RUN_TIME - Automatically stop the loadtest after this amount of time.
+#   The formatting of this value follows the timeout(1) duration spec.
+# * OVERRIDES_FILES - space-delimited list of filenames of settings files.
+#   These settings files will override the default settings in the order given.
+#
+###############################################################################
+
+error() {
+    error_message="$1"
+    echo "${error_message}"
+    exit 1
+}
+
+if [ -n "${JENKINS_HOME}" ] ; then
+    source util/jenkins-common.sh
+else
+    error "ERROR: Could not detect automation system."
+fi
+
+test -z "${TARGET_URL}" && error 'TARGET_URL parameter was not specified.'
+test -z "${TEST_COMPONENT}" && error 'TEST_COMPONENT parameter was not specified.'
+test -z "${NUM_CLIENTS}" && error 'NUM_CLIENTS parameter was not specified.'
+test -z "${HATCH_RATE}" && error 'HATCH_RATE parameter was not specified.'
+
+# Make sure we have access to scripts, such as merge_settings.
+pip install -e .
+
+final_settings_file=settings_files/${TEST_COMPONENT}.yml
+
+mkdir results
+
+# In case the automation system archives workspaces, we should make an attempt
+# to prevent settings files containing secrets from lingering.
+cleanup() {
+    echo "cleaning up lingering settings file..."
+    rm $final_settings_file
+}
+trap cleanup TERM  # SIGTERM implies jenkins abort button was pressed
+
+default_settings="settings_files/${TEST_COMPONENT}.yml.example"
+merge_settings $default_settings $OVERRIDES_FILES > $final_settings_file
+
+# Setup requirements for running a loadtest against the given component.
+make ${TEST_COMPONENT}
+
+# Setup locust command
+locust_cmd="locust \
+    --host=${TARGET_URL} -f loadtests/${TEST_COMPONENT} \
+    --no-web --clients=${NUM_CLIENTS} --hatch-rate=${HATCH_RATE}"
+
+# Install a timeout if the MAX_RUN_TIME parameter was specified.  The
+# --kill-after=10s option indicates that if locust has not exited after
+# receiving SIGTERM, kill it forcefully (SIGKILL).
+if [ -n "${MAX_RUN_TIME}" ]; then
+    locust_cmd="timeout --signal=TERM --kill-after=10s $MAX_RUN_TIME $locust_cmd"
+fi
+
+# Setup simultaneous logging to console + logfile, and run test
+($locust_cmd) 2>&1 | tee results/log.txt
+
+cleanup


### PR DESCRIPTION
run-loadtest.sh is an automation-system-agnostic script for running
loadtests.  It detects the automation system, and receives parameters as
environment variables.

One automation system, jenkins, is currently supported.

PERF-393