### PR TITLE
infrastructure for generating summary reports

### DIFF
--- a/helpers/markers.py
+++ b/helpers/markers.py
@@ -1,0 +1,112 @@
+"""
+This module causes logging of test start/stop and other critical events.
+
+The locust logging format is not necessarily stable, so we use the event hooks
+API to implement our own "stable" logging for later programmatic reference.
+
+Enable this feature in a load test by including the following lines in some
+form, near the begginning of the locustfile:
+
+    from helpers import markers
+    markers.install_event_markers()
+
+As of this writing, the events are:
+
+* locust_start_hatching
+* master_start_hatching
+* quitting
+* hatch_complete
+* edx_heartbeat
+"""
+import re
+import logging
+from datetime import datetime, timedelta
+
+LOG = logging.getLogger(__name__)
+
+# As of this writing, locust prefixes logs using the default datefmt used by
+# the python logging library:
+# https://github.com/locustio/locust/blob/v0.7.5/locust/log.py#L13
+# https://github.com/python/cpython/blob/master/Lib/logging/__init__.py#L492
+LOCUST_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S,%f'
+
+
+class EventMarker(object):
+    """
+    Simple event marker that logs on every call.
+    """
+    def __init__(self, name):
+        self.name = name
+
+    def _generate_log_message(self):
+        LOG.info('locust event: {}'.format(self.name))
+
+    def __call__(self, *args, **kwargs):
+        self._generate_log_message()
+
+
+class HeartbeatEventMarker(EventMarker):
+    """
+    Event marker which behaves like a heartbeat.
+
+    This marker implements a rate limit on logging to prevent flooding logs.
+    """
+    def __init__(self, name='edx_heartbeat', period=timedelta(seconds=30)):
+        super(HeartbeatEventMarker, self).__init__(name)
+        self.period = period
+        self._last_heartbeat = None
+
+    def __call__(self, *args, **kwargs):
+        if not self._last_heartbeat:
+            self._last_heartbeat = datetime.now()
+        elif self._last_heartbeat + self.period < datetime.now():
+            self._generate_log_message()
+            self._last_heartbeat = datetime.now()
+
+
+def install_event_markers():
+    """
+    Call this function from a locustfile to enable event markers in logging.
+    """
+    # "import locust" within this scope so that this module is importable by
+    # code running in environments which do not have locust installed.
+    import locust
+
+    # install simple event markers
+    locust.events.locust_start_hatching += EventMarker('locust_start_hatching')
+    locust.events.master_start_hatching += EventMarker('master_start_hatching')
+    locust.events.quitting += EventMarker('quitting')
+    locust.events.hatch_complete += EventMarker('hatch_complete')
+
+    # install heartbeat markers which are rate limited
+    heartbeat_handler = HeartbeatEventMarker()
+    locust.events.request_success += heartbeat_handler
+    locust.events.request_failure += heartbeat_handler
+
+
+def parse_logfile_event_marker(line_str):
+    """
+    Parse a logfile line as an event marker.
+
+    Parameters:
+        line_str (str): a line from the locust log for a load test with markers
+            enabled.
+
+    Returns:
+        dict: dict object with the following keys: 'time' (value is
+            datetime.datetime), and 'event' (value is string).
+    """
+    match = re.match(
+        '\[(.+)\] .+/INFO/{}: locust event: (.*)$'.format(re.escape(__name__)),
+        line_str,
+    )
+    obj = None
+    if match:
+        timestamp, event = match.group(1, 2)
+        obj = {
+            # Assume logging is UTC, and return tz-unaware datetime object
+            # which implies UTC.
+            'time': datetime.strptime(timestamp, LOCUST_TIMESTAMP_FORMAT),
+            'event': event,
+        }
+    return obj

--- a/loadtests/course_discovery/locustfile.py
+++ b/loadtests/course_discovery/locustfile.py
@@ -9,15 +9,16 @@ import random
 from locust import HttpLocust, task, TaskSet
 from locust.clients import HttpSession
 
-from helpers import settings
+from helpers import settings, markers
 from helpers.api import LocustEdxRestApiClient
-
 
 settings.init(
     __name__,
     required_data=['programs'],
     required_secrets=['oauth'],
 )
+
+markers.install_event_markers()
 
 
 class SelfInterruptingTaskSet(TaskSet):

--- a/loadtests/course_import/locustfile.py
+++ b/loadtests/course_import/locustfile.py
@@ -14,8 +14,8 @@ import random
 import time
 
 from locust import HttpLocust, TaskSet, task, events
+from helpers import settings, markers
 
-from helpers import settings
 settings.init(
     __name__,
     required_data=[
@@ -27,6 +27,8 @@ settings.init(
         'CMS_USER_PASSWORD',
     ],
 )
+
+markers.install_event_markers()
 
 
 class CourseImport(TaskSet):

--- a/loadtests/credentials/locustfile.py
+++ b/loadtests/credentials/locustfile.py
@@ -10,11 +10,13 @@ import random
 from locust import task, HttpLocust
 from locust.clients import HttpSession
 
-from helpers import settings
+from helpers import settings, markers
 from helpers.api import LocustEdxRestApiClient
 from helpers.auto_auth_tasks import AutoAuthTasks
 
 settings.init(__name__, required_data=['credentials'], required_secrets=['oauth'])
+
+markers.install_event_markers()
 
 CREDENTIAL_SERVICE_URL = settings.data['credentials']['url']['service']
 LMS_ROOT_URL = settings.data['credentials']['lms_url_root']

--- a/loadtests/csm/locustfile.py
+++ b/loadtests/csm/locustfile.py
@@ -31,11 +31,10 @@ from warnings import filterwarnings
 import MySQLdb as Database
 
 from helpers.raw_logs import RawLogger
-from helpers import datadog_reporting
+from helpers import datadog_reporting, settings, markers
 
 # load the test settings BEFORE django settings where they are used for
 # database configuration
-from helpers import settings
 settings.init(__name__, required_data=[
     'DB_ENGINE',
     'DB_HOST',
@@ -44,6 +43,8 @@ settings.init(__name__, required_data=[
     'DB_USER',
     'DB_PASSWORD',
 ])
+
+markers.install_event_markers()
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "csm.locustsettings"
 # Load django settings here to trigger edx-platform sys.path manipulations

--- a/loadtests/devstack/locustfile.py
+++ b/loadtests/devstack/locustfile.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from locust import HttpLocust, task, TaskSet
 
-from helpers import settings
+from helpers import settings, markers
 from helpers.auto_auth_tasks import AutoAuthTasks
 from helpers.mixins import EnrollmentTaskSetMixin
 
@@ -22,6 +22,8 @@ settings.init(__name__, required_data=[
     'LOCUST_MIN_WAIT',
     'LOCUST_MAX_WAIT',
 ])
+
+markers.install_event_markers()
 
 
 class LMSDevstackTasks(EnrollmentTaskSetMixin, AutoAuthTasks):

--- a/loadtests/discussions_api/locustfile.py
+++ b/loadtests/discussions_api/locustfile.py
@@ -23,9 +23,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 import requests
-
 from locust import HttpLocust
-
 from discussions_api.dapi import DiscussionsApiTasks
 from discussions_api.tasks.dapi_tasks import (
     DeleteCommentsTask,
@@ -39,10 +37,10 @@ from discussions_api.tasks.dapi_tasks import (
     PostCommentsTask,
     PostThreadsTask,
 )
+from helpers import settings, markers
 
 requests.packages.urllib3.disable_warnings()
 
-from helpers import settings
 settings.init(__name__, required_data=[
     'COURSE_ID',
     'VERBOSE',
@@ -50,6 +48,8 @@ settings.init(__name__, required_data=[
     'LOCUST_MIN_WAIT',
     'LOCUST_MAX_WAIT',
 ])
+
+markers.install_event_markers()
 
 
 class DiscussionsApiTest(DiscussionsApiTasks):

--- a/loadtests/ecommerce/locustfile.py
+++ b/loadtests/ecommerce/locustfile.py
@@ -8,14 +8,15 @@ from locust import HttpLocust, TaskSet
 
 from baskets import BasketsTasks
 from payment import CybersourcePaymentTasks
-from helpers import settings
-
+from helpers import settings, markers
 
 settings.init(
     __name__,
     required_data=['ecommerce'],
     required_secrets=['ecommerce', 'jwt'],
 )
+
+markers.install_event_markers()
 
 
 class EcommerceTest(TaskSet):

--- a/loadtests/enrollment/locustfile.py
+++ b/loadtests/enrollment/locustfile.py
@@ -11,11 +11,13 @@ import json
 import uuid
 import random
 from locust import HttpLocust, TaskSet, task
+from helpers import settings, markers
 
-from helpers import settings
 settings.init(__name__, required_data=[
     'COURSE_ID_LIST',
 ])
+
+markers.install_event_markers()
 
 EMAIL_USERNAME = "success"
 EMAIL_URL = "simulator.amazonses.com"

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -16,14 +16,16 @@ from proctoring import ProctoredExamTasks
 from module_render import ModuleRenderTasks
 from wiki_views import WikiViewTask
 from tracking import TrackingTasks
+from helpers import settings, markers
 
-from helpers import settings
 settings.init(__name__, required_data=[
     'courses',
     'LOCUST_TASK_SET',
     'LOCUST_MIN_WAIT',
     'LOCUST_MAX_WAIT',
 ])
+
+markers.install_event_markers()
 
 
 class LmsTest(LmsTasks):

--- a/loadtests/teams_discussion/locustfile.py
+++ b/loadtests/teams_discussion/locustfile.py
@@ -11,18 +11,17 @@ from collections import deque
 import json
 import random
 import string
-
 from locust import HttpLocust, task
-
 from helpers.auto_auth_tasks import AutoAuthTasks
+from helpers import settings, markers
 
-from helpers import settings
 settings.init(__name__, required_data=[
     'COURSE_ID',
     'LOCUST_MIN_WAIT',
     'LOCUST_MAX_WAIT',
 ])
 
+markers.install_event_markers()
 
 _dummy_chars = string.lowercase + ' '
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ setup(
         'settings_files': ['*.yml'],
     },
     entry_points = {
-        'console_scripts': ['merge_settings=util.merge_settings:main'],
+        'console_scripts': [
+            'merge_settings = util.merge_settings:main',
+            'generate_summary = util.generate_summary:main',
+        ],
     },
     # minimal set of requirements only corresponding to the scripts in
     # entry_points.

--- a/util/app_monitors.py
+++ b/util/app_monitors.py
@@ -1,0 +1,98 @@
+"""
+"""
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+from datetime import datetime, timedelta
+
+
+class AppMonitor(object):
+    """
+    Representation of a monitoring service web dashboard for a web app.
+    """
+
+    def __init__(self, monitoring_service_name, app_name):
+        self._monitoring_service_name = monitoring_service_name
+        self._app_name = app_name
+
+    @property
+    def app_name(self):
+        """
+        The name of the app being represented by this instance of the
+        monitoring service.
+        """
+        return self._app_name
+
+    @property
+    def monitoring_service_name(self):
+        """
+        The name of this monitoring service.
+        """
+        return self._monitoring_service_name
+
+    def url(self, begin_time=None, end_time=None):
+        """
+        Generate a dashboard URL for the configured app and the given
+        timeframe.
+
+        Parameters:
+            begin_time (datetime.datetime): beginning of timeframe to display
+            end_time (datetime.datetime): end of timeframe to display
+
+        Returns:
+            str: URL of the dashboard.
+        """
+        raise NotImplementedError()
+
+
+class NewRelicMonitor(AppMonitor):
+    """
+    This class represents the New Relic APM dashboard for a specific app.
+    """
+    NEWRELIC_APM_TEMPLATE = 'https://rpm.newrelic.com/accounts/{account_id}/applications/{app_id}'
+
+    def __init__(self, account_name=None, account_id=None, app_name=None, app_id=None,):
+        super(NewRelicMonitor, self).__init__(
+            'New Relic APM dashboard',
+            app_name,
+        )
+        self._account_name = account_name
+        self._account_id = account_id
+        self._app_name = app_name
+        self._app_id = app_id
+
+    def url(self, begin_time=None, end_time=None):
+        """
+        Generate an APM URL for this app and the given timeframe
+
+        This method is an implementation of the same-signature method in the
+        superclass.
+        """
+        # pad the time range by a few minutes for better visual context
+        begin_time_padded = begin_time - timedelta(minutes=4)
+        end_time_padded = end_time + timedelta(minutes=4)
+
+        url_without_times = self.NEWRELIC_APM_TEMPLATE.format(
+            account_id=self._account_id,
+            app_id=self._app_id,
+        )
+        query_data = {}
+        if begin_time:
+            # "%s" is the strftime syntax for the number of seconds since
+            # the Epoch.
+            query_data['tw[start]'] = begin_time.strftime('%s')
+            if end_time:
+                query_data['tw[end]'] = end_time.strftime('%s')
+            else:
+                # Due to a race condition in the jenkins job (locust handles
+                # SIGTERM after this script gets triggered rather than before),
+                # the end_time may not be known yet.  We just assume that the
+                # test will be ending soon, so just set the end time to now.
+                query_data['tw[end]'] = datetime.now().strftime('%s')
+        url = None
+        if query_data:
+            url = '{}?{}'.format(url_without_times, urlencode(query_data))
+        else:
+            url = url_without_times
+        return url

--- a/util/app_monitors_config.py
+++ b/util/app_monitors_config.py
@@ -1,0 +1,24 @@
+"""
+edX-specific monitoring apps.
+
+Not directly useful outside of edX, but stands as a helpful example.  For a
+list of supported monitoring apps, refer to util/app_monitors.py.
+"""
+from util.app_monitors import NewRelicMonitor
+
+# Manually entered by looking at the the NR web UI
+MONITORS = [
+    NewRelicMonitor(
+        account_name='edX-Root',
+        account_id='88178',
+        app_name='loadtest-edx-edxapp-lms',
+        app_id='3545617',
+    ),
+    NewRelicMonitor(
+        account_name='edX-Root',
+        account_id='88178',
+        app_name='loadtest-edx-ecommerce',
+        app_id='5371731',
+    ),
+    # TODO: fill in more monitors.
+]

--- a/util/generate_summary.py
+++ b/util/generate_summary.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+Generate a summary of a previous loadtest run in this environment.
+
+See for usage example in a jenkins job dsl:
+
+https://github.com/edx/jenkins-job-dsl/blob/master/testeng/jobs/loadtestDriver.groovy
+
+Prerequisites:
+    A logfile produced by util/run-loadtest.sh should be present in its
+    standard location.
+
+Output:
+    Produces summary on standard output in YAML format.  The structure is as
+    follows:
+
+    * monitoring_links:
+        * list of link text/url pairs pointing to monitoring dashboards.
+    * timeline:
+        * begin: ISO 8601 date for when the test began.
+        * end: ISO 8601 date for when the test ended.
+"""
+from datetime import timedelta
+import yaml
+import helpers.markers
+from util.app_monitors_config import MONITORS
+
+# Refer to util/run-loadtest.sh in case this file path changes.
+STANDARD_LOGFILE_PATH = "results/log.txt"
+
+
+def parse_logfile_events(logfile):
+    """
+    Parse the logfile for events
+
+    Parameters:
+        logfile (file): the file containing locust logs for a single load test
+
+    Returns:
+        iterator of (datetime.datetime, str) tuples: the parsed events in the
+            order they are encountered.
+    """
+    for line in logfile:
+        data = helpers.markers.parse_logfile_event_marker(line)
+        if data is not None:
+            yield (data['time'], data['event'])
+
+
+def get_time_bounds(logfile):
+    """
+    Determine when the load test started and stopped.
+
+    Parameters:
+        logfile (file): the file containing locust logs for a single load test
+
+    Returns:
+        two-tuple of datetime.datetime: the time bounds of the load test
+    """
+    begin_time = end_time = None
+    relevant_events = ['locust_start_hatching', 'edx_heartbeat', 'quitting']
+    relevant_times = [
+        time
+        for time, event
+        in parse_logfile_events(logfile)
+        if event in relevant_events
+    ]
+    begin_time, end_time = (min(relevant_times), max(relevant_times))
+    return (begin_time, end_time)
+
+
+def main():
+    """
+    Generate a summary of a previous load test run.
+
+    This script assumes "results/log.txt" is the logfile in question.
+    """
+    with open(STANDARD_LOGFILE_PATH) as logfile:
+        loadtest_begin_time, loadtest_end_time = get_time_bounds(logfile)
+
+    monitoring_links = []
+    for monitor in MONITORS:
+        monitoring_links.append({
+            'url': monitor.url(
+                begin_time=loadtest_begin_time,
+                end_time=loadtest_end_time,
+            ),
+            'text': u'{}: {} ({} — {})'.format(
+                monitor.monitoring_service_name,
+                monitor.app_name,
+                # We use naive datetimes (i.e. no attached tz) and just
+                # assume UTC all along.  Tacking on the "Z" implies UTC.
+                loadtest_begin_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                loadtest_end_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            ),
+        })
+    print(yaml.dump(
+        {
+            'timeline': {
+                'begin': loadtest_begin_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'end': loadtest_end_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            },
+            'monitoring_links': monitoring_links
+        },
+        default_flow_style=False,  # Represent objects using indented blocks
+                                   # rather than inline enclosures.
+        allow_unicode=True,
+    ))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds the "generate_summary" entry point.  It reads the
standard logfile path and generates a summary report on standard output.

In order to collect enough information, also add some markers to the
logging (via helpers.markers).

This functionality is used by parallel changes to the jenkins job DSL: https://github.com/edx/jenkins-job-dsl/pull/162

An example jenkins test run containing two build artifacts (one logfile, one summary file): https://test-jenkins.testeng.edx.org/job/run-simple-loadtest/44/