### PR TITLE
[teams_discussion] cause clients to retry joining teams

### DIFF
--- a/loadtests/teams_discussion/README.rst
+++ b/loadtests/teams_discussion/README.rst
@@ -1,0 +1,26 @@
+Teams Discussion Load Testing
+=============================
+
+This directory contains Locust tasks designed to exercise teams discussion
+behavior on the LMS and the teams API.
+
+Course Setup
+------------
+
+You must select a course to run this test against, and enable the teams feature
+following these instructions:
+
+http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/teams/teams_setup.html#enable-and-configure-teams
+
+You must also create at least one team for the locust clients to join.  The
+product of ``max_team_size``, and the number of teams you create is the maximum
+number of locust clients you can spawn.  Before re-running this test, remember
+to manually delete the team enrollments, or just recreate new teams.
+
+Settings
+--------
+
+Load tests are configured using a YAML file in the standard fashion.
+
+Use the course that you set up (see section "Course Setup" above) for the
+``COURSE_ID`` setting.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ pyzmq==15.2.0  # needed for distributed mode. remove after we start using locust
 # common loadtest requirements
 edx-opaque-keys==0.4
 lazy
+backoff==1.4.3
 
 # helpers use these
 dogapi==1.2.1


### PR DESCRIPTION
Before this commit, if a client tries to join a full team, it will fail,
then clog the logs with subsequent failed tasks (mostly create_thread).

After this commit, the client will retry joining different teams until
hopefully one is joined.  Only if a team is successfully joined, the
client will continue running subsequent tasks.

Also update docs to clarify the setup procedure and other
responsibilities.

---

FYI @MichaelRoytman 