### PR TITLE
Improve lms loadtests

### DIFF
--- a/helpers/auto_auth_tasks.py
+++ b/helpers/auto_auth_tasks.py
@@ -43,9 +43,16 @@ class AutoAuthTasks(TaskSet):
             verify=verify_ssl
         )
 
-        json_response = response.json()
-        self._username = json_response['username']
-        self._email = json_response['email']
-        self._password = json_response['password']
-        self._user_id = json_response['user_id']
-        self._anonymous_user_id = json_response['anonymous_id']
+        if response.status_code == 200:
+            try:
+                json_response = response.json()
+                self._username = json_response['username']
+                self._email = json_response['email']
+                self._password = json_response['password']
+                self._user_id = json_response['user_id']
+                self._anonymous_user_id = json_response['anonymous_id']
+                return True
+            except ValueError, KeyError:
+                pass
+
+        return False

--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -17,6 +17,7 @@ class EnrollmentTaskSetMixin(HeadersTaskSetMixin):
         """
         Enrolls the test's user in the course under test.
         """
+        success = True
         with self.client.post(
             '/change_enrollment',
             data={'course_id': course_id, 'enrollment_action': 'enroll'},
@@ -29,3 +30,5 @@ class EnrollmentTaskSetMixin(HeadersTaskSetMixin):
                     "Enrollment failed. Check to make sure that the course key is correct, "
                     "that the course is open for enrollment, and that that the course enrollment isn't full."
                 )
+                success = False
+        return success

--- a/loadtests/lms/authentication_views.py
+++ b/loadtests/lms/authentication_views.py
@@ -1,0 +1,23 @@
+from locust import task
+
+from base import LmsTasks
+
+
+class AuthenticationViewsTasks(LmsTasks):
+
+    @task(9)
+    def login_logout(self):
+        """
+        Test the primary login/logout endpoints.
+        """
+        if self.locust._is_logged_in:
+            self.logout()
+        else:
+            self.login()
+
+    @task(1)
+    def stop(self):
+        """
+        Switch to a new TaskSet.
+        """
+        self.interrupt()

--- a/loadtests/lms/base.py
+++ b/loadtests/lms/base.py
@@ -77,7 +77,7 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
         return success
 
     def logout(self):
-        response = self.client.get('/logout', name='logout')
+        response = self.client.get('/logout', name='logout', allow_redirects=False)
 
         success = response.ok
         if success:

--- a/loadtests/lms/base.py
+++ b/loadtests/lms/base.py
@@ -55,7 +55,8 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
 
     def auto_auth(self, *args, **kwargs):
         success = super(LmsTasks, self).auto_auth(*args, **kwargs)
-        if success and self._email and self._password:
+        if success and self._user_id and self._email and self._password:
+            self.locust._user_id = self._user_id
             self.locust._email = self._email
             self.locust._password = self._password
         return success

--- a/loadtests/lms/base.py
+++ b/loadtests/lms/base.py
@@ -75,6 +75,14 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
             self.locust._is_logged_in = True
         return success
 
+    def logout(self):
+        response = self.client.get('/logout', name='logout')
+
+        success = response.ok
+        if success:
+            self.locust._is_logged_in = False
+        return success
+
     def enroll(self, *args, **kwargs):
         success = super(LmsTasks, self).enroll(*args, **kwargs)
         if success:

--- a/loadtests/lms/base.py
+++ b/loadtests/lms/base.py
@@ -96,6 +96,8 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
 
             # If we failed to register the user, and this TaskSet is a child of the main LmsTest TaskSet, interrupt so
             # that we can select another TaskSet and try to register again.
+            #
+            # NOTE: this is basically a retry mechanism without backoff, so it may behoove us to add delays to this
             if self._is_child and not self.locust._is_registered:
                 self.interrupt()
 
@@ -104,6 +106,8 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
 
             # If we failed to log in, and this TaskSet is a child of the main LmsTest TaskSet, interrupt so
             # that we can select another TaskSet and try to log in again.
+            #
+            # NOTE: this is basically a retry mechanism without backoff, so it may behoove us to add delays to this
             if self._is_child and not self.locust._is_logged_in:
                 self.interrupt()
 
@@ -112,5 +116,7 @@ class LmsTasks(EnrollmentTaskSetMixin, EdxAppTasks):
 
             # If we failed to enroll, and this TaskSet is a child of the main LmsTest TaskSet, interrupt so
             # that we can select another TaskSet and try to enroll again.
+            #
+            # NOTE: this is basically a retry mechanism without backoff, so it may behoove us to add delays to this
             if self._is_child and not self.locust._is_enrolled:
                 self.interrupt()

--- a/loadtests/lms/courseware_views.py
+++ b/loadtests/lms/courseware_views.py
@@ -57,3 +57,10 @@ class CoursewareViewsTasks(LmsTasks):
         Request the LMS' internal about page for this course.
         """
         self.get('about', name='courseware:about')
+
+    @task(8)
+    def stop(self):
+        """
+        Switch to another TaskSet.
+        """
+        self.interrupt()

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -382,7 +382,7 @@ class ForumsTasks(BaseForumsTasks):
         super(ForumsTasks, self).on_start()
         self.topic_ids()
         if getattr(self.locust, '_my_thread_ids', None) is None:
-           self.locust._my_thread_ids = []
+            self.locust._my_thread_ids = []
 
 
 class SeedForumsTasks(BaseForumsTasks):

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -287,7 +287,7 @@ class ForumsTasks(BaseForumsTasks):
         """
         thread = super(ForumsTasks, self).create_thread(self.random_topic_id(), name='forums:create_thread')
         ForumsTasks._thread_ids.append(thread)
-        self._my_thread_ids.append(thread)
+        self.locust._my_thread_ids.append(thread)
 
     @task(1)
     def update_thread(self):
@@ -298,9 +298,9 @@ class ForumsTasks(BaseForumsTasks):
         threads which this locust user has created.  LMS users cannot edit each
         others' threads.
         """
-        if not self._my_thread_ids:
+        if not self.locust._my_thread_ids:
             return
-        discussion_id, thread_id = random.choice(self._my_thread_ids)
+        discussion_id, thread_id = random.choice(self.locust._my_thread_ids)
         super(ForumsTasks, self).update_thread(thread_id)
 
     @task(36)
@@ -351,7 +351,7 @@ class ForumsTasks(BaseForumsTasks):
         Request the user profile endpoint.
         """
         self.get(
-            'discussion/forum/users/{}'.format(self._user_id),
+            'discussion/forum/users/{}'.format(self.locust._user_id),
             name='forums:get_user_profile',
         )
 
@@ -361,7 +361,7 @@ class ForumsTasks(BaseForumsTasks):
         Request the followed threads endpoint.
         """
         self.get(
-            'discussion/forum/users/{}/followed'.format(self._user_id),
+            'discussion/forum/users/{}/followed'.format(self.locust._user_id),
             headers={"X-Requested-With": "XMLHttpRequest"},  # non-ajax requests don't work here.
             name='forums:followed_threads',
         )
@@ -381,7 +381,8 @@ class ForumsTasks(BaseForumsTasks):
         """
         super(ForumsTasks, self).on_start()
         self.topic_ids()
-        self._my_thread_ids = []
+        if getattr(self.locust, '_my_thread_ids', None) is None:
+           self.locust._my_thread_ids = []
 
 
 class SeedForumsTasks(BaseForumsTasks):

--- a/loadtests/lms/forums.py
+++ b/loadtests/lms/forums.py
@@ -366,6 +366,13 @@ class ForumsTasks(BaseForumsTasks):
             name='forums:followed_threads',
         )
 
+    @task(11)
+    def stop(self):
+        """
+        Switch to another TaskSet.
+        """
+        self.interrupt()
+
     def on_start(self):
         """
         This on_start method performs the following actions:

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -150,5 +150,11 @@ class LmsLocust(HttpLocust):
 
     def __init__(self, *args, **kwargs):
         super(LmsLocust, self).__init__(*args, **kwargs)
-        self._is_authenticated = False
+        self._email = None
+        self._password = None
+        self._is_logged_in = False
         self._is_enrolled = False
+
+    @property
+    def _is_registered(self):
+        return bool(self._email and self._password)

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -152,6 +152,7 @@ class LmsLocust(HttpLocust):
 
     def __init__(self, *args, **kwargs):
         super(LmsLocust, self).__init__(*args, **kwargs)
+        self._user_id = None
         self._email = None
         self._password = None
         self._is_logged_in = False
@@ -159,4 +160,4 @@ class LmsLocust(HttpLocust):
 
     @property
     def _is_registered(self):
-        return bool(self._email and self._password)
+        return bool(self._user_id and self._email and self._password)

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -147,3 +147,8 @@ class LmsLocust(HttpLocust):
     task_set = globals()[settings.data['LOCUST_TASK_SET']]
     min_wait = settings.data['LOCUST_MIN_WAIT']
     max_wait = settings.data['LOCUST_MAX_WAIT']
+
+    def __init__(self, *args, **kwargs):
+        super(LmsLocust, self).__init__(*args, **kwargs)
+        self._is_authenticated = False
+        self._is_enrolled = False

--- a/loadtests/lms/locustfile.py
+++ b/loadtests/lms/locustfile.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from locust import HttpLocust
 
+from authentication_views import AuthenticationViewsTasks
 from courseware_views import CoursewareViewsTasks
 from forums import ForumsTasks, SeedForumsTasks
 from base import LmsTasks
@@ -135,6 +136,7 @@ class LmsTest(LmsTasks):
     """
 
     tasks = {
+        AuthenticationViewsTasks: 1,
         CoursewareViewsTasks: 5,
         ForumsTasks: 1,
         ModuleRenderTasks: int(round(22 * float(settings.data.get('MODULE_RENDER_MODIFIER', 1)))),

--- a/loadtests/lms/module_render.py
+++ b/loadtests/lms/module_render.py
@@ -336,3 +336,10 @@ class ModuleRenderTasks(LmsTasks):
             data=data,
             name="handler:video:save_user_state"
         )
+
+    @task(9)
+    def stop(self):
+        """
+        Switch to another TaskSet.
+        """
+        self.interrupt()

--- a/loadtests/lms/proctoring.py
+++ b/loadtests/lms/proctoring.py
@@ -29,7 +29,7 @@ class ProctoredExamTasks(LmsTasks):
         response_data = json.loads(response.text)
         self.attempt_id = response_data.get('exam_attempt_id')
 
-    @task(1)
+    @task(9)
     def exam_poll_attempt(self):
         """
         Retrieves the status of an existing exam attempt.
@@ -42,3 +42,10 @@ class ProctoredExamTasks(LmsTasks):
             '{url}/{attempt_id}'.format(url=self.attempt_api_path, attempt_id=attempt_id),
             name='timed_exam:poll_attempt'
         )
+
+    @task(1)
+    def stop(self):
+        """
+        Switch to another TaskSet.
+        """
+        self.interrupt()

--- a/loadtests/lms/tracking.py
+++ b/loadtests/lms/tracking.py
@@ -27,7 +27,7 @@ class TrackingTasks(LmsTasks):
         random_chars = (choice(char_pool) for _ in xrange(length))
         return ''.join(random_chars)
 
-    @task(1)
+    @task(9)
     def report_event(self):
         """
         POST a user tracking event.  This simulates event reports such as
@@ -50,3 +50,10 @@ class TrackingTasks(LmsTasks):
         }
 
         response = self.client.post(EVENT_API_PATH, data=data, headers=self.post_headers)
+
+    @task(1)
+    def stop(self):
+        """
+        Switch to another TaskSet.
+        """
+        self.interrupt()

--- a/settings_files/lms.yml.example
+++ b/settings_files/lms.yml.example
@@ -21,6 +21,9 @@ courses:
         #large_topic_id:
         #large_thread_id:
 
+# Path to the primary login endpoint
+LOGIN_PATH: '/login_ajax'
+
 # Run the specified TaskSet (must be imported into the lms/locustfile.py
 # file):
 LOCUST_TASK_SET: LmsTest

--- a/settings_files/lms.yml.sandbox-example
+++ b/settings_files/lms.yml.sandbox-example
@@ -8,6 +8,9 @@ COURSE_ID: course-v1:edX+DemoX+Demo_Course
 # module.
 COURSE_DATA: demo_course
 
+# Path to the primary login endpoint
+LOGIN_PATH: '/login_ajax'
+
 # Run the specified TaskSet (must be imported into the lms/locustfile.py
 # file):
 LOCUST_TASK_SET: LmsTasks


### PR DESCRIPTION
Improves the LMS loadtests so that:
- Locust users do not get locked in to a single TaskSet.
- AutoAuth/Login/Enroll failures can be retried.
- The Login endpoint can be load tested.
